### PR TITLE
[StudyBadge_FE #6]: 메인페이지 레이아웃 순서정렬요소 추가

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -67,6 +67,29 @@ const Main = (): JSX.Element => {
             </div>
           </div>
         </div>
+        <div className="w-full flex justify-end cursor-pointer px-8 mb-4 relative">
+          <div className="bg-white border border-solid border-Gray-2 px-2 py-1 rounded-[10px] flex items-center">
+            {/* 최신순/조회순 두 가지 정렬 */}
+            최신순
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="currentColor"
+              className="bi bi-caret-down-fill text-Gray-2 ml-2"
+              viewBox="0 0 16 16"
+            >
+              <path d="M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z" />
+            </svg>
+          </div>
+          {/* 클릭하면 뜨게 할 선택드롭다운 */}
+          <div className="absolute top-8 w-[84px] bg-white border border-solid border-Gray-2 rounded-[10px] flex flex-col">
+            <div className="w-full px-2 py-1 border-b border-solid border-Gray-2 rounded-t-[10px] text-center hover:bg-Gray-1">
+              최신순
+            </div>
+            <div className="w-full px-2 py-1 text-center rounded-b-[10px] hover:bg-Gray-1">조회순</div>
+          </div>
+        </div>
         <div className="study-cards-container w-full flex justify-center items-center flex-wrap">
           {/* 받은 채널 리스트의 길이만큼 map을 이용해 Card 생성 */}
           <Card studyInfo={""} />


### PR DESCRIPTION

  ## 🔘Part
  - FE
 
  ## 🔎 작업 내용
- 레이아웃에 리스트 순서 정렬을 선택할 수 있는
- 최신순/조회순 드롭다운 디자인요소를 삽입했습니다.
 
  ## 화면 이미지 첨부
![스크린샷 2024-07-11 171617](https://github.com/StudyBadge-TenTen/StudyBadge_FE/assets/155413929/35401717-819a-4979-bbc1-74b0e9dcf3d6)

  ## ➕ 이슈 링크
  - issue링크
